### PR TITLE
Workflow: package and release on tag

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -8,18 +8,21 @@ on:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Test
+        run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Publish release
+
+on:
+  push:
+    tags: [ "v*.*.*" ]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        dotnet: [5.0.x]
+        runtime: [linux-x64, win10-x64, osx.11.0-x64]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install tooling
+        run: sudo apt-get install -qq zip
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
+
+      - name: Publish
+        run: dotnet publish -r ${{ matrix.runtime }} -c Release -o ./out src/Cli/hashfields.csproj
+
+      - name: Zip
+        run: |
+          zip -r -j hashfields-${{ matrix.runtime }}-${{ matrix.dotnet }}.zip out/
+          ls -l hashfields-${{ matrix.runtime }}-${{ matrix.dotnet }}.zip
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: package
+          path: hashfields-${{ matrix.runtime }}-${{ matrix.dotnet }}.zip
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: package
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: package
+          path: ./package
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "./package/*.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,16 +37,27 @@ jobs:
       - name: Publish
         run: dotnet publish -r ${{ matrix.runtime }} -c Release -o ./out src/Cli/hashfields.csproj
 
-      - name: Zip
+      - name: Make artifact path
+        id: make-path
+        env:
+          ref: ${{ github.ref }}
+          runtime: ${{ matrix.runtime }}
+          dotnet: ${{ matrix.dotnet }}
         run: |
-          zip -r -j hashfields-${{ matrix.runtime }}-${{ matrix.dotnet }}.zip out/
-          ls -l hashfields-${{ matrix.runtime }}-${{ matrix.dotnet }}.zip
+          echo "::set-output name=path::hashfields-${ref/refs\/tags\//}-$runtime-$dotnet.zip"
+
+      - name: Zip
+        env:
+          path: ${{ steps.make-path.outputs.path }}
+        run: |
+          zip -r -j $path out/
+          ls -l $path
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: package
-          path: hashfields-${{ matrix.runtime }}-${{ matrix.dotnet }}.zip
+          path: ${{ steps.make-path.outputs.path }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           runtime: ${{ matrix.runtime }}
           dotnet: ${{ matrix.dotnet }}
         run: |
-          echo "::set-output name=path::hashfields-${ref/refs\/tags\//}-$runtime-$dotnet.zip"
+          echo "::set-output name=path::hashfields-${ref/refs\/tags\//}-$runtime-dotnet-$dotnet.zip"
 
       - name: Zip
         env:


### PR DESCRIPTION
## Overview

Closes #2

* workflow runs on a tag of the form `v*.*.*` e.g. `v1.2.3`
* workflow consists of two jobs: `package` and `release`

### `package`

* run the dotnet build process using a matrix strategy for different versions / runtime targets
* generate and zip output for a given target
* upload zip as GitHub Actions artifact

### `release`

* blocked until package finishes successfully
* download all GitHub Actions artifacts (from all matrix builds)
* make new GitHub Release, attaching all artifacts

## Testing this Workflow

I forked the repository over at https://github.com/thekaveman/hashfields.

* Actions runs here: https://github.com/thekaveman/hashfields/actions/workflows/release.yml
* (generated) Releases here: https://github.com/thekaveman/hashfields/releases