### PR TITLE
Skip CI test runs for non-code changes

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -3,8 +3,19 @@ name: Run tests
 on:
   push:
     branches: [ main ]
+    paths:
+      - .github/workflows/dotnet-test.yml
+      - 'src/**'
+      - 'tests/**'
+      - HashFields.sln
+
   pull_request:
     branches: [ "*" ]
+    paths:
+      - .github/workflows/dotnet-test.yml
+      - 'src/**'
+      - 'tests/**'
+      - HashFields.sln
 
 jobs:
   test:


### PR DESCRIPTION
Tests are only run in CI if changes are in files matching a reduced subset of `paths`.

Closes #7 