### PR TITLE
Feat: output hashed values as hexadecimal strings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "editor.formatOnSave": true,
+    "editor.formatOnType": true,
     "files.encoding": "utf8",
     "files.eol": "\n",
     "files.insertFinalNewline": true,

--- a/src/Cli/Options/DataOptions.cs
+++ b/src/Cli/Options/DataOptions.cs
@@ -13,6 +13,10 @@ namespace HashFields.Cli.Options
 
         public string HashAlgorithm { get; set; } = StringHasher.SupportedAlgorithms.Last();
 
+        public bool HyphenateHashes { get; set; } = true;
+
+        public bool LowercaseHashes { get; set; } = false;
+
         public List<string> Drop { get; } = new List<string>();
 
         public List<string> Skip { get; } = new List<string>();

--- a/src/Cli/Services/HashFieldsService.cs
+++ b/src/Cli/Services/HashFieldsService.cs
@@ -49,8 +49,16 @@ namespace HashFields.Cli.Services
             csv.Remove(dropColumns);
 
             var hashColumns = csv.Header.Except(_dataOptions.Skip).ToArray();
+            // wrap the stringHasher.Hash function with params from _dataOptions
+            // to create a hashFunc for the csv.Apply() call
+            Func<string, string> hashFunc = (input) =>
+                stringHasher.Hash(
+                    input,
+                    hyphens: _dataOptions.HyphenateHashes,
+                    lowercase: _dataOptions.LowercaseHashes
+                );
             _logger.LogInformation("Hashing columns: {{{}}}", String.Join(", ", hashColumns));
-            csv.Apply(stringHasher.Hash, hashColumns);
+            csv.Apply(hashFunc, hashColumns);
 
             _logger.LogInformation("Writing results");
             using var destination = _optionsStreamService.Get();

--- a/src/Cli/Services/HashFieldsService.cs
+++ b/src/Cli/Services/HashFieldsService.cs
@@ -51,7 +51,7 @@ namespace HashFields.Cli.Services
             var hashColumns = csv.Header.Except(_dataOptions.Skip).ToArray();
             // wrap the stringHasher.Hash function with params from _dataOptions
             // to create a hashFunc for the csv.Apply() call
-            Func<string, string> hashFunc = (input) =>
+            string hashFunc(string input) =>
                 stringHasher.Hash(
                     input,
                     hyphens: _dataOptions.HyphenateHashes,

--- a/src/Cli/appsettings.json
+++ b/src/Cli/appsettings.json
@@ -6,6 +6,8 @@
             "column3"
         ],
         "HashAlgorithm": "sha256",
+        "HyphenateHashes": "false",
+        "LowercaseHashes": "true",
         "Skip": [
             "column2"
         ]

--- a/src/Data/StringHasher.cs
+++ b/src/Data/StringHasher.cs
@@ -39,7 +39,7 @@ namespace HashFields.Data
             using var algo = GetAlgorithm();
             var hashed = algo.ComputeHash(data);
 
-            return Encoding.UTF8.GetString(hashed);
+            return BitConverter.ToString(hashed);
         }
 
         private HashAlgorithm GetAlgorithm()

--- a/src/Data/StringHasher.cs
+++ b/src/Data/StringHasher.cs
@@ -5,6 +5,9 @@ using System.Text;
 
 namespace HashFields.Data
 {
+    /// <summary>
+    /// Converts input strings into their hashed, hexadecimal string equivalents using a configurable hashing algorithm.
+    /// </summary>
     public class StringHasher
     {
         public static readonly string[] SupportedAlgorithms =
@@ -16,10 +19,18 @@ namespace HashFields.Data
 
         private readonly string _algorithm;
 
+        /// <summary>
+        /// Initialize a new StringHasher using the default hashing algorithm.
+        /// </summary>
         public StringHasher() : this(SupportedAlgorithms.Last())
         {
         }
 
+        /// <summary>
+        /// Initialize a new StringHasher that uses the given hashing algorithm.
+        /// </summary>
+        /// <param name="hashAlgorithm">The name of one of the supported hashing algorithms, e.g. "SHA256".</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="hashAlgorithm" /> is not a supported hashing algorithm.</exception>
         public StringHasher(string hashAlgorithm)
         {
             if (SupportedAlgorithms.Contains(hashAlgorithm, StringComparer.OrdinalIgnoreCase))
@@ -32,6 +43,15 @@ namespace HashFields.Data
             }
         }
 
+        /// <summary>
+        /// Produce a hashed string version of an input string, using this StringHasher's algorithm.
+        /// Output hashes are formatted like those from <c>System.BitConverter.ToString(byte[])</c>.
+        /// </summary>
+        /// <see cref="System.BitConverter.ToString(byte[])" />
+        /// <param name="input">The input string to hash.</param>
+        /// <param name="hyphens">Whether to produce the output hash with hyphens separating each byte. The default is <c>true</c>.</param>
+        /// <param name="lowercase">Whether to produce the output hash using lowercase hexadecimal digits. The default is <c>false</c>.</param>
+        /// <returns>A string contained the hashed input string.</returns>
         public string Hash(string input, bool hyphens = true, bool lowercase = false)
         {
             var data = Encoding.UTF8.GetBytes(input);

--- a/src/Data/StringHasher.cs
+++ b/src/Data/StringHasher.cs
@@ -32,14 +32,23 @@ namespace HashFields.Data
             }
         }
 
-        public string Hash(string input)
+        public string Hash(string input, bool hyphens = true, bool lowercase = false)
         {
             var data = Encoding.UTF8.GetBytes(input);
 
             using var algo = GetAlgorithm();
-            var hashed = algo.ComputeHash(data);
+            var hashed = BitConverter.ToString(algo.ComputeHash(data));
 
-            return BitConverter.ToString(hashed);
+            if (!hyphens)
+            {
+                hashed = hashed.Replace("-", "");
+            }
+            if (lowercase)
+            {
+                hashed = hashed.ToLower();
+            }
+
+            return hashed;
         }
 
         private HashAlgorithm GetAlgorithm()

--- a/src/Data/StringHasher.cs
+++ b/src/Data/StringHasher.cs
@@ -51,7 +51,7 @@ namespace HashFields.Data
         /// <param name="input">The input string to hash.</param>
         /// <param name="hyphens">Whether to produce the output hash with hyphens separating each byte. The default is <c>true</c>.</param>
         /// <param name="lowercase">Whether to produce the output hash using lowercase hexadecimal digits. The default is <c>false</c>.</param>
-        /// <returns>A string contained the hashed input string.</returns>
+        /// <returns>A string containing the hashed input string.</returns>
         public string Hash(string input, bool hyphens = true, bool lowercase = false)
         {
             var data = Encoding.UTF8.GetBytes(input);

--- a/tests/Cli/OptionsTests/DataOptionsTests.cs
+++ b/tests/Cli/OptionsTests/DataOptionsTests.cs
@@ -21,6 +21,8 @@ namespace HashFields.Cli.Options.Tests
                 ["DataOptions:Drop:0"] = "a",
                 ["DataOptions:Drop:1"] = "b",
                 ["DataOptions:HashAlgorithm"] = "algo",
+                ["DataOptions:HyphenateHashes"] = "false",
+                ["DataOptions:LowercaseHashes"] = "true",
                 ["DataOptions:Skip:0"] = "1",
                 ["DataOptions:Skip:1"] = "2",
                 ["DataOptions:Skip:2"] = "3"
@@ -75,6 +77,44 @@ namespace HashFields.Cli.Options.Tests
             var dataOptions = config.GetSection("DataOptions").Get<DataOptions>();
 
             Assert.IsNotNull(dataOptions.HashAlgorithm);
+        }
+
+        [TestMethod]
+        public void HyphenateHashes()
+        {
+            Assert.AreEqual(false, _options.HyphenateHashes);
+        }
+
+        [TestMethod]
+        public void Deafult_HyphenateHashes()
+        {
+            var config = new ConfigurationBuilder()
+                // don't provide a HyphenateHashes key-value
+                .AddInMemoryCollection(new[] { KeyValuePair.Create("DataOptions:Delimiter", "delim") })
+                .Build();
+
+            var dataOptions = config.GetSection("DataOptions").Get<DataOptions>();
+
+            Assert.IsTrue(dataOptions.HyphenateHashes);
+        }
+
+        [TestMethod]
+        public void LowercaseHashes()
+        {
+            Assert.AreEqual(true, _options.LowercaseHashes);
+        }
+
+        [TestMethod]
+        public void Deafult_LowercaseHashes()
+        {
+            var config = new ConfigurationBuilder()
+                // don't provide a LowercaseHashes key-value
+                .AddInMemoryCollection(new[] { KeyValuePair.Create("DataOptions:Delimiter", "delim") })
+                .Build();
+
+            var dataOptions = config.GetSection("DataOptions").Get<DataOptions>();
+
+            Assert.IsFalse(dataOptions.LowercaseHashes);
         }
 
         [TestMethod]

--- a/tests/Data/StringHasherTests.cs
+++ b/tests/Data/StringHasherTests.cs
@@ -79,7 +79,7 @@ namespace HashFields.Data.Tests
 
         [DataTestMethod]
         [DataRow("sha256", "Some input text", "13265aa4b59f216746001b732078ed8b6ccb1d0470d8c3da710d8539214b80d3")]
-        public void Hash_RemovesHyphensAndMakesLower(string hashAlgorithm, string inputText, string expected)
+        public void Hash_RemovesHyphensAndMakesLowercase(string hashAlgorithm, string inputText, string expected)
         {
             var hasher = new StringHasher(hashAlgorithm);
             var actual = hasher.Hash(inputText, hyphens: false, lowercase: true);

--- a/tests/Data/StringHasherTests.cs
+++ b/tests/Data/StringHasherTests.cs
@@ -1,7 +1,6 @@
 using System;
-using System.Text;
 using System.Security.Cryptography;
-
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HashFields.Data.Tests
@@ -45,18 +44,15 @@ namespace HashFields.Data.Tests
         }
 
         [DataTestMethod]
-        [DataRow("sha256", "Some input text")]
-        [DataRow("sha384", "Very diFfeRent !npUT .txt")]
+        [DataRow("sha256", "Some input text", "13-26-5A-A4-B5-9F-21-67-46-00-1B-73-20-78-ED-8B-6C-CB-1D-04-70-D8-C3-DA-71-0D-85-39-21-4B-80-D3")]
+        [DataRow("sha384", "Very diFfeRent !npUT .txt", "F2-2C-92-82-E6-DB-AC-C5-4E-E5-40-FE-6D-7F-AB-29-22-69-53-1D-29-03-CF-A8-FF-D0-F9-74-64-36-DE-BC-2C-38-EA-E5-69-44-B3-18-3B-DD-A4-E9-BE-74-4E-43")]
         [DataRow("sha512", @"Very very very long input text that spans multiple lines.
 
         That was just the first line before, but this is a second line all on its own.
 
-        Third line!!! There are some blank lines between lines as well!")]
-        public void Hash_HashesString_UsingAlgorithm(string hashAlgorithm, string inputText)
+        Third line!!! There are some blank lines between lines as well!", "BE-1C-83-A0-B4-3A-5C-84-64-58-8C-9C-83-99-E0-C9-CA-8B-6F-C4-6F-4F-DA-29-1E-DD-62-88-13-50-AD-6F-88-FD-20-7A-9C-1E-F2-5E-41-BB-DD-B3-F5-D9-37-B7-E7-FB-09-6A-50-8A-49-9F-36-DC-28-91-A4-AA-C7-AD")]
+        public void Hash_HashesString_UsingAlgorithm(string hashAlgorithm, string inputText, string expected)
         {
-            var inputBytes = Encoding.UTF8.GetBytes(inputText);
-            var expected = Encoding.UTF8.GetString(HashAlgorithm.Create(hashAlgorithm).ComputeHash(inputBytes));
-
             var hasher = new StringHasher(hashAlgorithm);
             var actual = hasher.Hash(inputText);
 

--- a/tests/Data/StringHasherTests.cs
+++ b/tests/Data/StringHasherTests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HashFields.Data.Tests
@@ -55,6 +53,36 @@ namespace HashFields.Data.Tests
         {
             var hasher = new StringHasher(hashAlgorithm);
             var actual = hasher.Hash(inputText);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("sha256", "Some input text", "13-26-5a-a4-b5-9f-21-67-46-00-1b-73-20-78-ed-8b-6c-cb-1d-04-70-d8-c3-da-71-0d-85-39-21-4b-80-d3")]
+        public void Hash_MakesLowercase(string hashAlgorithm, string inputText, string expected)
+        {
+            var hasher = new StringHasher(hashAlgorithm);
+            var actual = hasher.Hash(inputText, lowercase: true);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("sha256", "Some input text", "13265AA4B59F216746001B732078ED8B6CCB1D0470D8C3DA710D8539214B80D3")]
+        public void Hash_RemovesHyphens(string hashAlgorithm, string inputText, string expected)
+        {
+            var hasher = new StringHasher(hashAlgorithm);
+            var actual = hasher.Hash(inputText, hyphens: false);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("sha256", "Some input text", "13265aa4b59f216746001b732078ed8b6ccb1d0470d8c3da710d8539214b80d3")]
+        public void Hash_RemovesHyphensAndMakesLower(string hashAlgorithm, string inputText, string expected)
+        {
+            var hasher = new StringHasher(hashAlgorithm);
+            var actual = hasher.Hash(inputText, hyphens: false, lowercase: true);
 
             Assert.AreEqual(expected, actual);
         }


### PR DESCRIPTION
Closes #11

## More info

The default way to do this in .NET is with [`System.BitConverter.ToString(Byte[])`](https://docs.microsoft.com/en-us/dotnet/api/system.bitconverter.tostring?view=net-6.0#System_BitConverter_ToString_System_Byte___) which produces strings like:

```
13-26-5A-A4-B5-9F-21-67-46-00-1B-73-20-78-ED-8B-6C-CB-1D-04-70-D8-C3-DA-71-0D-85-39-21-4B-80-D3
```

In other programming languages (notably, python's `hashlib.hexdigest()` methods), this value is output without the hyphens, in lowercase.

The `StringHasher.Hash()` method has been overridden with options to strip the hyphens and/or convert to lowercase, and these options are exposed in the `DataOptions` class that is bound to `appsettings.json`:

```jsonc
{
    "DataOptions": {
        "Delimiter": ",",
        "Drop": [
            "column1",
            "column3"
        ],
        "HashAlgorithm": "sha256",
        "HyphenateHashes": "false", //<--- new boolean option (default: true)
        "LowercaseHashes": "true",  //<--- new boolean option (default: false)
        "Skip": [
            "column2"
        ]
    },
    "StreamOptions": {
        "Input": {
            "Path": "./samples/data.csv",
            "Type": "File"
        },
        "Output": {
            "Path": "./samples/data.hashed.csv",
            "Type": "File"
        }
    }
}
```