### PR TITLE
Fix: Columnar handling of duplicate column values

### DIFF
--- a/src/Data/Csv/Columnar.cs
+++ b/src/Data/Csv/Columnar.cs
@@ -73,61 +73,6 @@ namespace HashFields.Data.Csv
             }
         }
 
-        public bool Equals(Columnar other)
-        {
-            if (other is null)
-            {
-                return false;
-            }
-
-            if (!_header.SequenceEqual(other._header))
-            {
-                return false;
-            }
-
-            foreach (var column in _data)
-            {
-                if (!column.Value.SequenceEqual(other._data[column.Key]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is null)
-            {
-                return false;
-            }
-
-            if (obj is not Columnar columnar)
-            {
-                return false;
-            }
-
-            return Equals(columnar);
-        }
-
-        public override int GetHashCode()
-        {
-            var hashcode = new HashCode();
-            foreach (var header in _header)
-            {
-                hashcode.Add(header);
-            }
-            foreach (var column in _data.Values)
-            {
-                foreach (var val in column)
-                {
-                    hashcode.Add(val);
-                }
-            }
-            return hashcode.ToHashCode();
-        }
-
         /// <summary>
         /// Remove the named columns from this <c>Columnar</c> data.
         /// The column names should match those found in the <c>Header</c>.
@@ -246,5 +191,64 @@ namespace HashFields.Data.Csv
                 )
             );
         }
+
+        #region IEquatable<Columnar>
+
+        public bool Equals(Columnar other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (!_header.SequenceEqual(other._header))
+            {
+                return false;
+            }
+
+            foreach (var column in _data)
+            {
+                if (!column.Value.SequenceEqual(other._data[column.Key]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (obj is not Columnar columnar)
+            {
+                return false;
+            }
+
+            return Equals(columnar);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashcode = new HashCode();
+            foreach (var header in _header)
+            {
+                hashcode.Add(header);
+            }
+            foreach (var column in _data.Values)
+            {
+                foreach (var val in column)
+                {
+                    hashcode.Add(val);
+                }
+            }
+            return hashcode.ToHashCode();
+        }
+
+        #endregion
     }
 }

--- a/src/Data/Csv/Columnar.cs
+++ b/src/Data/Csv/Columnar.cs
@@ -104,16 +104,7 @@ namespace HashFields.Data.Csv
             }
         }
 
-        public void Write(Stream destination)
-        {
-            using var sw = new StreamWriter(destination);
-            foreach (var row in Rows())
-            {
-                sw.WriteLine(String.Join(",", row));
-            }
-        }
-
-        private List<List<string>> Rows()
+        public List<List<string>> Rows()
         {
             var rows = Enumerable.Range(0, Columns.Max(c => c.Count))
                                  .Select(_ => new List<string>())
@@ -121,15 +112,24 @@ namespace HashFields.Data.Csv
 
             foreach (var column in Columns)
             {
-                foreach (var val in column)
+                for (int i = 0; i < column.Count; i++)
                 {
-                    rows[column.IndexOf(val)].Add(val);
+                    rows[i].Add(column[i]);
                 }
             }
 
             rows.Insert(0, Header);
 
             return rows;
+        }
+
+        public void Write(Stream destination)
+        {
+            using var sw = new StreamWriter(destination);
+            foreach (var row in Rows())
+            {
+                sw.WriteLine(String.Join(",", row));
+            }
         }
 
         private static Tuple<List<string>, Dictionary<string, List<string>>> Parse(Stream stream, string delimiter)

--- a/src/Data/Csv/Columnar.cs
+++ b/src/Data/Csv/Columnar.cs
@@ -15,6 +15,7 @@ namespace HashFields.Data.Csv
     {
         private readonly List<string> _header = new();
         private readonly Dictionary<string, List<string>> _data = new();
+        private readonly string _delimiter;
 
         /// <summary>
         /// The column of values by column name.
@@ -49,7 +50,9 @@ namespace HashFields.Data.Csv
         {
             if (stream is not null)
             {
-                var tuple = Parse(stream, delimiter);
+                _delimiter = delimiter;
+
+                var tuple = Parse(stream, _delimiter);
 
                 _header = tuple.Item1;
                 _data = tuple.Item2;
@@ -129,7 +132,7 @@ namespace HashFields.Data.Csv
             using var sw = new StreamWriter(destination);
             foreach (var row in Rows())
             {
-                sw.WriteLine(String.Join(",", row));
+                sw.WriteLine(String.Join(_delimiter, row));
             }
         }
 

--- a/tests/Data/Csv/ColumnarTests.cs
+++ b/tests/Data/Csv/ColumnarTests.cs
@@ -102,13 +102,13 @@ namespace HashFields.Data.Csv.Tests
             var columnar = NewColumnar(data);
 
             var header = columnar.Header.ToArray();
-            CollectionAssert.AreEquivalent(new[] { "1", "2", "3" }, header);
+            CollectionAssert.AreEqual(new[] { "1", "2", "3" }, header);
 
             Assert.AreEqual(3, columnar.Columns.Count);
 
             foreach (var column in columnar.Columns)
             {
-                CollectionAssert.AreEquivalent(new List<string>(), column);
+                CollectionAssert.AreEqual(new List<string>(), column);
             }
         }
 
@@ -128,7 +128,7 @@ namespace HashFields.Data.Csv.Tests
             var columnar = NewColumnar(_data);
 
             var header = columnar.Header.ToArray();
-            CollectionAssert.AreEquivalent(new[] { "1", "a", "!" }, header);
+            CollectionAssert.AreEqual(new[] { "1", "a", "!" }, header);
 
             Assert.AreEqual(3, columnar.Columns.Count);
 
@@ -138,15 +138,15 @@ namespace HashFields.Data.Csv.Tests
 
                 if (column == "1")
                 {
-                    CollectionAssert.AreEquivalent(new[] { "2", "3" }, columnar[column]);
+                    CollectionAssert.AreEqual(new[] { "2", "3" }, columnar[column]);
                 }
                 else if (column == "a")
                 {
-                    CollectionAssert.AreEquivalent(new[] { "b", "c" }, columnar[column]);
+                    CollectionAssert.AreEqual(new[] { "b", "c" }, columnar[column]);
                 }
                 else if (column == "!")
                 {
-                    CollectionAssert.AreEquivalent(new[] { "@", "#" }, columnar[column]);
+                    CollectionAssert.AreEqual(new[] { "@", "#" }, columnar[column]);
                 }
             }
         }
@@ -176,13 +176,13 @@ namespace HashFields.Data.Csv.Tests
             var columnar = NewColumnar(data);
 
             var header = columnar.Header.ToArray();
-            CollectionAssert.AreEquivalent(new[] { "1", "2", "3" }, header);
+            CollectionAssert.AreEqual(new[] { "1", "2", "3" }, header);
 
             Assert.AreEqual(3, columnar.Columns.Count);
 
             foreach (var column in columnar.Columns)
             {
-                CollectionAssert.AreEquivalent(new List<string>(), column);
+                CollectionAssert.AreEqual(new List<string>(), column);
             }
         }
 
@@ -202,7 +202,7 @@ namespace HashFields.Data.Csv.Tests
             Assert.AreEqual(1, columnar.Header.Count);
             Assert.AreEqual(1, columnar.Columns.Count);
             Assert.IsTrue(columnar.Header.Contains(expectedHeader));
-            CollectionAssert.AreEquivalent(columnar.Columns[0], expectedColumn);
+            CollectionAssert.AreEqual(columnar.Columns[0], expectedColumn);
         }
 
         [DataTestMethod]

--- a/tests/Data/Csv/ColumnarTests.cs
+++ b/tests/Data/Csv/ColumnarTests.cs
@@ -256,5 +256,70 @@ namespace HashFields.Data.Csv.Tests
             Assert.IsTrue(columnar.Header.Contains("1"));
             Assert.IsTrue(columnar.Header.Contains("!"));
         }
+
+        [TestMethod]
+        public void Rows_MultiRow()
+        {
+            var columner = NewColumnar(_data);
+
+            var rows = columner.Rows();
+
+            Assert.AreEqual(3, rows.Count);
+            CollectionAssert.AreEqual(new[] { "1", "a", "!" }, rows[0]);
+            CollectionAssert.AreEqual(new[] { "2", "b", "@" }, rows[1]);
+            CollectionAssert.AreEqual(new[] { "3", "c", "#" }, rows[2]);
+        }
+
+        [TestMethod]
+        public void Rows_MultiRow_Duplicates()
+        {
+            var data = Encoding.UTF8.GetBytes(@"
+                1, a, !
+                2, a, @
+                3, c, #
+                4, d, #
+            ");
+
+            var columnar = NewColumnar(data);
+
+            var rows = columnar.Rows();
+
+            Assert.AreEqual(4, rows.Count);
+            CollectionAssert.AreEqual(new[] { "1", "a", "!" }, rows[0]);
+            CollectionAssert.AreEqual(new[] { "2", "a", "@" }, rows[1]);
+            CollectionAssert.AreEqual(new[] { "3", "c", "#" }, rows[2]);
+            CollectionAssert.AreEqual(new[] { "4", "d", "#" }, rows[3]);
+        }
+
+        [TestMethod]
+        public void Rows_SingleRow()
+        {
+            var data = Encoding.UTF8.GetBytes("1, a, !");
+
+            var columnar = NewColumnar(data);
+
+            var rows = columnar.Rows();
+
+            Assert.AreEqual(1, rows.Count);
+            CollectionAssert.AreEqual(new[] { "1", "a", "!" }, rows[0]);
+        }
+
+        [TestMethod]
+        public void Write_EndsWithNewline()
+        {
+            var text = String.Join(Environment.NewLine, new[] { "1, a, !", "2, b, @", "3, c, #" });
+
+            Assert.IsFalse(text.EndsWith(Environment.NewLine));
+
+            var data = Encoding.UTF8.GetBytes(text);
+            var columnar = NewColumnar(data);
+            var destination = new MemoryStream();
+
+            columnar.Write(destination);
+
+            var result = Encoding.UTF8.GetString(destination.ToArray());
+
+            StringAssert.EndsWith(result, Environment.NewLine);
+        }
     }
 }

--- a/tests/Data/Csv/ColumnarTests.cs
+++ b/tests/Data/Csv/ColumnarTests.cs
@@ -217,6 +217,31 @@ namespace HashFields.Data.Csv.Tests
             }
         }
 
+        [TestMethod]
+        public void New_TrimsFieldValues()
+        {
+            var data = Encoding.UTF8.GetBytes(@"
+            1,      a,           !
+            2,      b,           @
+            3,      c,           #
+            4,      d,           $
+            ");
+
+            var columnar = NewColumnar(data);
+
+            var header = columnar.Header.ToArray();
+            CollectionAssert.AreEqual(new[] { "1", "a", "!" }, header);
+
+            foreach (var column in columnar.Columns)
+            {
+                foreach (var value in column)
+                {
+                    Assert.IsFalse(value.StartsWith(" "));
+                    Assert.IsFalse(value.EndsWith(" "));
+                }
+            }
+        }
+
         [DataTestMethod]
         [DataRow(new[] { "1", "a" })]
         [DataRow(new[] { "1", "!" })]

--- a/tests/Data/Csv/ColumnarTests.cs
+++ b/tests/Data/Csv/ColumnarTests.cs
@@ -127,23 +127,9 @@ namespace HashFields.Data.Csv.Tests
 
             Assert.AreEqual(3, columnar.Columns.Count);
 
-            foreach (var column in header)
-            {
-                Assert.AreEqual(2, columnar[column].Count);
-
-                if (column == "1")
-                {
-                    CollectionAssert.AreEqual(new[] { "2", "3" }, columnar[column]);
-                }
-                else if (column == "a")
-                {
-                    CollectionAssert.AreEqual(new[] { "b", "c" }, columnar[column]);
-                }
-                else if (column == "!")
-                {
-                    CollectionAssert.AreEqual(new[] { "@", "#" }, columnar[column]);
-                }
-            }
+            CollectionAssert.AreEqual(new[] { "2", "3" }, columnar["1"]);
+            CollectionAssert.AreEqual(new[] { "b", "c" }, columnar["a"]);
+            CollectionAssert.AreEqual(new[] { "@", "#" }, columnar["!"]);
         }
 
         [TestMethod]
@@ -158,10 +144,9 @@ namespace HashFields.Data.Csv.Tests
             const string delimiter = "<>";
             var columnar = NewColumnar(data, delimiter);
 
-            foreach (var elem in columnar["2"].Union(columnar["3"].Union(columnar["5"])))
-            {
-                CollectionAssert.Contains(new[] { "4", "6", "9", "10", "15" }, elem);
-            }
+            CollectionAssert.AreEqual(new[] { "4", "6" }, columnar["2"]);
+            CollectionAssert.AreEqual(new[] { "6", "9" }, columnar["3"]);
+            CollectionAssert.AreEqual(new[] { "10", "15" }, columnar["5"]);
         }
 
         [TestMethod]
@@ -181,23 +166,9 @@ namespace HashFields.Data.Csv.Tests
 
             Assert.AreEqual(3, columnar.Columns.Count);
 
-            foreach (var column in header)
-            {
-                Assert.AreEqual(3, columnar[column].Count);
-
-                if (column == "1")
-                {
-                    CollectionAssert.AreEqual(new[] { "2", "3", "4" }, columnar[column]);
-                }
-                else if (column == "a")
-                {
-                    CollectionAssert.AreEqual(new[] { "b", "", "d" }, columnar[column]);
-                }
-                else if (column == "!")
-                {
-                    CollectionAssert.AreEqual(new[] { "", "#", "$" }, columnar[column]);
-                }
-            }
+            CollectionAssert.AreEqual(new[] { "2", "3", "4" }, columnar["1"]);
+            CollectionAssert.AreEqual(new[] { "b", "", "d" }, columnar["a"]);
+            CollectionAssert.AreEqual(new[] { "", "#", "$" }, columnar["!"]);
         }
 
         [TestMethod]
@@ -221,10 +192,10 @@ namespace HashFields.Data.Csv.Tests
         public void New_TrimsFieldValues()
         {
             var data = Encoding.UTF8.GetBytes(@"
-            1,      a,           !
-            2,      b,           @
-            3,      c,           #
-            4,      d,           $
+            1      ,      a    ,           !
+            2      ,      b    ,           @
+            3      ,      c    ,           #
+            4      ,      d    ,           $
             ");
 
             var columnar = NewColumnar(data);
@@ -339,7 +310,7 @@ namespace HashFields.Data.Csv.Tests
 
             var result = Encoding.UTF8.GetString(destination.ToArray());
 
-            StringAssert.EndsWith(result, Environment.NewLine);
+            Assert.IsTrue(result.EndsWith(Environment.NewLine));
         }
 
         [TestMethod]

--- a/tests/Data/Csv/ColumnarTests.cs
+++ b/tests/Data/Csv/ColumnarTests.cs
@@ -341,5 +341,20 @@ namespace HashFields.Data.Csv.Tests
 
             StringAssert.EndsWith(result, Environment.NewLine);
         }
+
+        [TestMethod]
+        public void Write_UsesDelimiter()
+        {
+            const string text = "1|a|!\n2|b|@\n3|c|#\n";
+            var data = Encoding.UTF8.GetBytes(text);
+            var columnar = NewColumnar(data, delimiter: "|");
+            var destination = new MemoryStream();
+
+            columnar.Write(destination);
+
+            var result = Encoding.UTF8.GetString(destination.ToArray());
+
+            Assert.AreEqual(text, result);
+        }
     }
 }

--- a/tests/Data/Csv/ColumnarTests.cs
+++ b/tests/Data/Csv/ColumnarTests.cs
@@ -170,6 +170,42 @@ namespace HashFields.Data.Csv.Tests
         }
 
         [TestMethod]
+        public void New_MultiRow_BlankValues_Initializes_HeaderAndColumns()
+        {
+            var data = Encoding.UTF8.GetBytes(@"
+                1, a, !
+                2, b,
+                3,, #
+                4, d, $
+            ");
+
+            var columnar = NewColumnar(data);
+
+            var header = columnar.Header.ToArray();
+            CollectionAssert.AreEqual(new[] { "1", "a", "!" }, header);
+
+            Assert.AreEqual(3, columnar.Columns.Count);
+
+            foreach (var column in header)
+            {
+                Assert.AreEqual(3, columnar[column].Count);
+
+                if (column == "1")
+                {
+                    CollectionAssert.AreEqual(new[] { "2", "3", "4" }, columnar[column]);
+                }
+                else if (column == "a")
+                {
+                    CollectionAssert.AreEqual(new[] { "b", "", "d" }, columnar[column]);
+                }
+                else if (column == "!")
+                {
+                    CollectionAssert.AreEqual(new[] { "", "#", "$" }, columnar[column]);
+                }
+            }
+        }
+
+        [TestMethod]
         public void New_SingleRow_Initializes_HeaderAndColumns()
         {
             var data = Encoding.UTF8.GetBytes("1, 2, 3");

--- a/tests/Data/Csv/ColumnarTests.cs
+++ b/tests/Data/Csv/ColumnarTests.cs
@@ -32,14 +32,9 @@ namespace HashFields.Data.Csv.Tests
 
             columnar.Apply(val => val + "_mod", "2");
 
-            foreach (var elem in columnar["2"])
-            {
-                CollectionAssert.Contains(new[] { "4_mod", "6_mod" }, elem);
-            }
-            foreach (var elem in columnar["3"].Union(columnar["5"]))
-            {
-                CollectionAssert.Contains(new[] { "6", "9", "10", "15" }, elem);
-            }
+            CollectionAssert.AreEqual(new[] { "4_mod", "6_mod" }, columnar["2"]);
+            CollectionAssert.AreEqual(new[] { "6", "9" }, columnar["3"]);
+            CollectionAssert.AreEqual(new[] { "10", "15" }, columnar["5"]);
         }
 
         [TestMethod]
@@ -55,10 +50,10 @@ namespace HashFields.Data.Csv.Tests
 
             columnar.Apply(val => val + "_mod", "z");
 
-            foreach (var elem in columnar["2"].Union(columnar["3"].Union(columnar["5"])))
-            {
-                CollectionAssert.Contains(new[] { "4", "6", "9", "10", "15" }, elem);
-            }
+            CollectionAssert.AreEqual(new[] { "2", "3", "5" }, columnar.Header);
+            CollectionAssert.AreEqual(new[] { "4", "6" }, columnar["2"]);
+            CollectionAssert.AreEqual(new[] { "6", "9" }, columnar["3"]);
+            CollectionAssert.AreEqual(new[] { "10", "15" }, columnar["5"]);
         }
 
         [TestMethod]

--- a/tests/Data/Csv/ColumnarTests.cs
+++ b/tests/Data/Csv/ColumnarTests.cs
@@ -280,9 +280,9 @@ namespace HashFields.Data.Csv.Tests
         [TestMethod]
         public void Rows_MultiRow()
         {
-            var columner = NewColumnar(_data);
+            var columnar = NewColumnar(_data);
 
-            var rows = columner.Rows();
+            var rows = columnar.Rows();
 
             Assert.AreEqual(3, rows.Count);
             CollectionAssert.AreEqual(new[] { "1", "a", "!" }, rows[0]);


### PR DESCRIPTION
Closes #13.

## The bug

This was a tricky one! But a silly mistake in retrospect. The code that transforms columns into rows previously looked like (pseudocode):

```csharp
// a list of lists of the row values
rows = [[],[],[],[]]

foreach (column in columns)
{
    foreach (value in column)
    {
        rows[column.index(value)].add(value)
    }
}
```

So finding the index of `value` in the `column`, and using that to add the `value` to the end of the corresponding row list. 

Finding the index only gets the index of the first occurrence of the `value`! So when `column` contains duplicates, subsequent `value`s are appended to the same row list over and over.

## The fix

This was a really simple fix, just iterating over the column indices directly:

```csharp
rows = [[],[],[],[]]

foreach (column in columns)
{
    for (i = 0; i < column.count; i++)
    {
        rows[i].add(column[i])
    }
}
```

Tests have been added to ensure the correct behavior for duplicate column values.