### PR TITLE
Fix: ensure matrix strategy applies to runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,12 @@ jobs:
         id: make-path
         env:
           ref: ${{ github.ref }}
-          runtime: ${{ matrix.runtime }}
+          os: ${{ matrix.os }}
         run: |
-          echo "path=hashfields-${ref/refs\/tags\//}-$runtime.zip" >> $GITHUB_OUTPUT
+          # strip off the -latest, replace ubuntu with linux
+          os=${os/-latest/}
+          os=${os/ubuntu/linux}
+          echo "path=hashfields-${ref/refs\/tags\//}-${os}.zip" >> $GITHUB_OUTPUT
 
       - name: Zip
         env:


### PR DESCRIPTION
Before this fix, the workflow was always running in the `ubuntu-latest` runner, which means the `pyinstaller` for Windows and MacOS did not produce viable executables for those platforms.

This fix ensure the matrix strategy in the workflow applies to the runner, meaning the runner is actually varied between the 3 target platforms.